### PR TITLE
Add required dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine 
 
 RUN apk update && \
-	apk add openvpn iptables socat curl
+	apk add openvpn iptables socat curl openssl
 
 ADD ./bin /sbin
 


### PR DESCRIPTION
I had to add `openssl` in order to run the container successfully. Otherwise it was complaining because the package was missing.